### PR TITLE
Save content an indented json

### DIFF
--- a/app/components/Home.js
+++ b/app/components/Home.js
@@ -99,7 +99,7 @@ export default class Home extends React.Component {
       note.content.preview_plain = "Created with Secure Spreadsheets";
 
       var json = this.getJSON();
-      var content = JSON.stringify(json);
+      var content = JSON.stringify(json, null, 2);
       note.content.text = content;
     });
   }


### PR DESCRIPTION
Saving content in a single-line make it impossible to use in Android app (application either open files for 2-3 seconds or crashes). Saving content as indented solve this problem, but extension do it single-line again on change. 

This should fix it.